### PR TITLE
Invert PageUp and PageDown shortcuts

### DIFF
--- a/data/Shortcuts.ui
+++ b/data/Shortcuts.ui
@@ -84,14 +84,14 @@
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
                 <property name="title" translatable="yes" context="shortcut window">Previous page</property>
-                <property name="accelerator">&lt;Primary&gt;Page_Up</property>
+                <property name="accelerator">&lt;Primary&gt;Page_Down</property>
               </object>
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
                 <property name="visible">True</property>
                 <property name="title" translatable="yes" context="shortcut window">Next page</property>
-                <property name="accelerator">&lt;Primary&gt;Page_Down</property>
+                <property name="accelerator">&lt;Primary&gt;Page_Up</property>
               </object>
             </child>
             <child>

--- a/src/application.py
+++ b/src/application.py
@@ -315,10 +315,10 @@ class Application(Gtk.Application):
                                    ["<Alt>Right", "XF86Forward"])
         self.set_accels_for_action("win.shortcut::next",
                                    ["<Control>Tab",
-                                    "<Control>Page_Up"])
+                                    "<Control>Page_Down"])
         self.set_accels_for_action("win.shortcut::previous",
                                    ["<Control><Shift>Tab",
-                                    "<Control>Page_Down"])
+                                    "<Control>Page_Up"])
         self.set_accels_for_action("win.shortcut::zoom_in",
                                    ["<Control>KP_Add", "<Control>plus"])
         self.set_accels_for_action("win.shortcut::zoom_out",


### PR DESCRIPTION
It seems they are actually inverted.

PageUp should go Up, PageDown down. (currently it's the opposite)