### PR TITLE
Install webextension into libdir

### DIFF
--- a/eolie.in
+++ b/eolie.in
@@ -19,6 +19,7 @@ from gi.repository import Gio
 
 localedir = '@localedir@'
 pkgdatadir = '@pkgdatadir@'
+pkglibdir = '@pkglibdir@'
 
 from eolie.application import Application
 
@@ -45,7 +46,7 @@ if __name__ == "__main__":
     resource = Gio.resource_load(os.path.join(pkgdatadir, 'eolie.gresource'))
     Gio.Resource._register(resource)
 
-    app = Application("@VERSION@", os.path.join(pkgdatadir, 'webkitextension'))
+    app = Application("@VERSION@", os.path.join(pkglibdir, 'webkitextension'))
     signal.signal(signal.SIGINT, signal.SIG_DFL)
     if 'EOLIE_TRACE' in os.environ:
         graphviz = GraphvizOutput()

--- a/python-webextension/Makefile.am
+++ b/python-webextension/Makefile.am
@@ -3,7 +3,7 @@
 # Adrian Perez, 2015-08-25 11:58
 #
 
-webkitextensiondir = $(datadir)/eolie/webkitextension
+webkitextensiondir = $(libdir)/eolie/webkitextension
 webkitextension_DATA = extension.py
 
 extension.py: extension.py.in Makefile


### PR DESCRIPTION
Only platform-independent data is allowed in datadir, so libpythonloader.so should be installed below /lib instead of /share.